### PR TITLE
Make logThis method protected in order to solve synchronization problem

### DIFF
--- a/src/CppVec.h
+++ b/src/CppVec.h
@@ -18,11 +18,14 @@ public:
 
 	void initCppVector(std::string, std::string);
 	VClock getCurrentVC();
-	bool logThis(std::string, std::string);
 	bool logLocalEvent(std::string);
 	template <typename T> char* prepareSend(std::string message, T payload);
 	template <typename T> void unpackReceive(std::string message, char* buffer, 
 		T* unpack, int numBytes);
+
+protected:
+
+	bool logThis(std::string, std::string);
 
 private:
 


### PR DESCRIPTION
LogThis and LogLocalEvent can be called in parallel as they are both exposed as public API functions which can result in a lack of consistency in the event logs written to the log file.